### PR TITLE
Update indexer.py

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -2,17 +2,21 @@
 # -*- coding: utf-8 -*-
 
 import os
+import re
 
 base = [x[0] for x in os.walk("./base")]
-indexes = []
-for i in range(1,len(base)):
-    with open(base[i] + "/Readme.md", "r") as readme:
-        texto = readme.readlines()
-        indexes.append(("- [%s](%s/Readme.md#qxcode)\n" % (texto[1].strip()[3:], base[i])))
-
+tags = {'ope':[], 'sel':[], 'rep':[], 'vet':[], 'cha':[], 'str':[], 'mat':[], 'arq':[]}
 
 with open("./indice.md", "w+") as saida:
-    saida.write("# @qxcode\n\nArquivo a ser gerado automaticamente a partir dos títulos das questões.\n\n")
-    for linha in indexes:
-        saida.write(linha)
+    saida.write("# @qxcode\n\nArquivo a ser gerado automaticamente a partir dos títulos das questões.")
+    for i in range(1,len(base)):
+        with open(base[i] + "/Readme.md", "r") as readme:
+            texto = readme.readlines()
+            tags[texto[1].partition("## [")[2].partition("]")[0]].append((("- [%s](%s/Readme.md#qxcode)\n" % (texto[1].strip()[3:], base[i]))))
 
+    for tag in tags:
+        tags[tag] = sorted(tags[tag], key=lambda x : int(re.compile(".*?(?:[a-z][a-z]*[0-9]+[a-z0-9]*).*?((?:[a-z][a-z]*[0-9]+[a-z0-9]*))",re.IGNORECASE|re.DOTALL).search(x).group(1)[1]))
+        saida.write("\n\n")
+        saida.write("## %s\n" % tag)
+        for questao in tags[tag]:
+            saida.write(questao)


### PR DESCRIPTION
Corrigindo a ordenação, estava dando erro para tags com mais de 3 letras, agora a busca pelo nível da questão é feita com um RegEx e assim não importa quantas letras a tag possua.